### PR TITLE
Updated EIP-1108 with the new gas costs

### DIFF
--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -34,8 +34,8 @@ the computational cost of `ECADD`, `ECMUL`, and pairing checks (excepting the
 constant) has dropped roughly an order of magnitude across the board.
 
 Also, [optimisations in the bn library](https://github.com/paritytech/bn/pull/9) 
-used by [Parity client](https://github.com/paritytech/parity-ethereum) led to a 
-significant performance boost that we 
+used by the [Parity client](https://github.com/paritytech/parity-ethereum) led to a 
+significant performance boost we 
 [benchmarked](https://gist.github.com/pdyraga/4649b74436940a01e8221d85e80bfeef) 
 and compared against the [previous 
 results](https://github.com/ethereum/benchmarking/blob/master/constantinople/analysis2.md). 
@@ -53,10 +53,10 @@ Following is a table with the current gas cost and new gas cost:
 The gas costs for `ECADD` and `ECMUL` are updates to the costs listed in
 EIP-196, while the gas costs for the pairing check are updates to the cost
 listed in EIP-197. Updated gas costs have been adjusted to the less performant 
-client which is Parity according to benchmarks<sup>[3]</sup>.
+client which is Parity, according to benchmarks<sup>[3]</sup>.
 
 [1]- Per [EIP-196](https://github.com/ethereum/EIPs/blob/984cf5de90bbf5fbe7e49be227b0c2f9567e661e/EIPS/eip-196.md#gas-costs).
 
 [2]- Per [EIP-197](https://github.com/ethereum/EIPs/blob/df132cd37efb3986f9cd3ef4922b15a767d2c54a/EIPS/eip-197.md#specification).
 
-[3]- Per [Parity benchmarks](https://gist.github.com/pdyraga/4649b74436940a01e8221d85e80bfeef)
+[3]- [Parity benchmarks.](https://gist.github.com/pdyraga/4649b74436940a01e8221d85e80bfeef)

--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -48,7 +48,7 @@ Following is a table with the current gas cost and new gas cost:
 | ------------- | --------- | -----------------------------  | ------------------- |
 | `ECADD`       | `0x06`    | 500<sup>[1]</sup>              | 150                 |
 | `ECMUL`       | `0x07`    | 40 000<sup>[1]</sup>           | 6 000               |
-| Pairing check | `0x08`    | 80 000k + 100 000<sup>[2]</sup>| 28 300k + 35 450    |
+| Pairing check | `0x08`    | 80 000 * k + 100 000<sup>[2]</sup>| 28 300 * k + 35 450    |
 
 The gas costs for `ECADD` and `ECMUL` are updates to the costs listed in
 EIP-196, while the gas costs for the pairing check are updates to the cost

--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -13,8 +13,12 @@ requires: 196, 197
 
 Recent changes to the underlying library used by the official Go reference
 implementation led to significant performance gains for the `ECADD`, `ECMUL`,
-and pairing check precompiled contracts on the `alt_bn128` elliptic curve, which
-should be reflected in reduced gas costs.
+and pairing check precompiled contracts on the `alt_bn128` elliptic curve.
+
+What is more, the performance boost for those operations can be also observed 
+for Parity client. 
+
+Faster operations on Ethereum clients should be reflected in reduced gas costs.
 
 ## Motivation
 
@@ -29,20 +33,30 @@ note](https://github.com/ethereum/go-ethereum/pull/16301#issuecomment-372687543)
 the computational cost of `ECADD`, `ECMUL`, and pairing checks (excepting the
 constant) has dropped roughly an order of magnitude across the board.
 
+Also, [optimisations in the bn library](https://github.com/paritytech/bn/pull/9) 
+used by [Parity client](https://github.com/paritytech/parity-ethereum) led to a 
+significant performance boost that we 
+[benchmarked](https://gist.github.com/pdyraga/4649b74436940a01e8221d85e80bfeef) 
+and compared against the [previous 
+results](https://github.com/ethereum/benchmarking/blob/master/constantinople/analysis2.md). 
+
 ## Specification
 
 Following is a table with the current gas cost and new gas cost:
 
 | Contract      | Address   | Current Gas Cost               | Updated Gas Cost    |
 | ------------- | --------- | -----------------------------  | ------------------- |
-| `ECADD`       | `0x06`    | 500<sup>[1]</sup>              | 50                  |
-| `ECMUL`       | `0x07`    | 40 000<sup>[1]</sup>           | 2 000               |
-| Pairing check | `0x08`    | 80 000k + 100 000<sup>[2]</sup>| 5 500k + 80 000     |
+| `ECADD`       | `0x06`    | 500<sup>[1]</sup>              | 150                 |
+| `ECMUL`       | `0x07`    | 40 000<sup>[1]</sup>           | 6 000               |
+| Pairing check | `0x08`    | 80 000k + 100 000<sup>[2]</sup>| 28 300k + 35 450    |
 
 The gas costs for `ECADD` and `ECMUL` are updates to the costs listed in
 EIP-196, while the gas costs for the pairing check are updates to the cost
-listed in EIP-197.
+listed in EIP-197. Updated gas costs have been adjusted to the less performant 
+client which is Parity according to benchmarks<sup>[3]</sup>.
 
 [1]- Per [EIP-196](https://github.com/ethereum/EIPs/blob/984cf5de90bbf5fbe7e49be227b0c2f9567e661e/EIPS/eip-196.md#gas-costs).
 
 [2]- Per [EIP-197](https://github.com/ethereum/EIPs/blob/df132cd37efb3986f9cd3ef4922b15a767d2c54a/EIPS/eip-197.md#specification).
+
+[3]- Per [Parity benchmarks](https://gist.github.com/pdyraga/4649b74436940a01e8221d85e80bfeef)


### PR DESCRIPTION
We benchmarked Parity client and adjusted proposed new gas costs to the
results. (Parity is slower than Go-Ethereum)

- proposed `ECADD` cost has been updated to 150
- proposed `ECMUL` cost has been updated to 6 000
- proposed pairing check cost has been updated to 28 300k + 35 450.

Pairing check cost has been scaled down by 2.82 factor, since Parity,
after the recent updates, is `~2.82` times faster for pairing check.
